### PR TITLE
Fix/#2 add proper error handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -135,7 +135,7 @@ def main(
     # Remove complete files from unprocessed
     for original_file in (
         # filename.complete_ext.ext -> filename.ext
-        x.parent / f"{x.stem.replace(f".{complete_ext}", '')}{x.suffix}"
+        x.parent / f"{x.stem.replace(f'.{complete_ext}', '')}{x.suffix}"
         for x in complete_files
     ):
         unprocessed_files.discard(original_file)

--- a/poetry.lock
+++ b/poetry.lock
@@ -466,14 +466,14 @@ hook-testing = ["execnet (>=1.5.0)", "psutil", "pytest (>=2.7.3)"]
 
 [[package]]
 name = "pyinstaller-hooks-contrib"
-version = "2025.0"
+version = "2025.1"
 description = "Community maintained hooks for PyInstaller"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "pyinstaller_hooks_contrib-2025.0-py3-none-any.whl", hash = "sha256:3c0623799c3f81a37293127f485d65894c20fd718f722cb588785a3e52581ad1"},
-    {file = "pyinstaller_hooks_contrib-2025.0.tar.gz", hash = "sha256:6dc0b55a1acaab2ffee36ed4a05b073aa0a22e46f25fb5c66a31e217454135ed"},
+    {file = "pyinstaller_hooks_contrib-2025.1-py3-none-any.whl", hash = "sha256:d3c799470cbc0bda60dcc8e6b4ab976777532b77621337f2037f558905e3a8e9"},
+    {file = "pyinstaller_hooks_contrib-2025.1.tar.gz", hash = "sha256:130818f9e9a0a7f2261f1fd66054966a3a50c99d000981c5d1db11d3ad0c6ab2"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,12 +32,13 @@ select = [
     "ALL", # include all the rules, including new ones
 ]
 ignore = [
-    "E501", # line too long    
-    "D102", # missing docstring in public method
-    "D212", # multiline docstring should start at the first line (personal preference)
-    "D107", # missing docstring in __init__ (lol why)
-    "D400", # first line should end with a period (sometimes mess with markdown or code blocks)
-    "D415", # first line should end with a period (same as above but trickier)
+    "E501",   # line too long    
+    "D102",   # missing docstring in public method
+    "D212",   # multiline docstring should start at the first line (personal preference)
+    "D107",   # missing docstring in __init__ (lol why)
+    "D400",   # first line should end with a period (sometimes mess with markdown or code blocks)
+    "D415",   # first line should end with a period (same as above but trickier)
+    "RUF001", # unused variable
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/src/logger.py
+++ b/src/logger.py
@@ -40,8 +40,7 @@ class AppLogger:
             self._log.info(f"⏳ {msg}")
 
     def skip_lines(self, count: int) -> None:
-        for _ in range(count):
-            self.console.print("\n" * count, end="")
+        self.console.print("\n" * count, end="")
 
 
 log = AppLogger()

--- a/src/logger.py
+++ b/src/logger.py
@@ -1,3 +1,5 @@
+"""Logger for the application."""
+
 import logging
 
 from rich.console import Console
@@ -15,29 +17,31 @@ logging.basicConfig(
 
 
 class AppLogger:
-    def __init__(self):
+    """Wrapper around the logging library with some extra features."""
+
+    def __init__(self) -> None:
         self._log = logging.getLogger(__name__)
         self.console = _console
 
-    def info(self, msg, should_log=True):
+    def info(self, msg: str, *, should_log: bool = True) -> None:
         if should_log:
             self._log.info(f"ℹ {msg}")
 
-    def success(self, msg, should_log=True):
+    def success(self, msg: str, *, should_log: bool = True) -> None:
         if should_log:
             self._log.info(f"✔ {msg}")
 
-    def error(self, msg, should_log=True):
+    def error(self, msg: str, *, should_log: bool = True) -> None:
         if should_log:
             self._log.error(f"❌ {msg}")
 
-    def wait(self, msg, should_log=True):
+    def wait(self, msg: str, *, should_log: bool = True) -> None:
         if should_log:
             self._log.info(f"⏳ {msg}")
 
-    def skip_lines(self, count):
+    def skip_lines(self, count: int) -> None:
         for _ in range(count):
-            print("\n" * count, end="")
+            self.console.print("\n" * count, end="")
 
 
 log = AppLogger()

--- a/src/third_party_installers.py
+++ b/src/third_party_installers.py
@@ -1,3 +1,5 @@
+"""The module provides a class to install a software on Windows, Linux, and macOS."""
+
 import os
 import subprocess
 
@@ -7,11 +9,22 @@ from src.logger import log
 
 
 class InstallCommand(BaseModel):
+    """
+    Class representing a command to install a software on Windows, Linux, and macOS.
+
+    You should specify how to install the software on each platform.
+    """
+
     win: str
     linux: str
     mac: str
 
-    def run(self):
+    def run(self) -> None:
+        """
+        Run the install command for the current platform.
+
+        The platform is detected using the `os.name` variable.
+        """
         if os.name == "nt":
             cmd = self.win
         elif os.name == "posix":
@@ -19,9 +32,8 @@ class InstallCommand(BaseModel):
         else:
             cmd = self.mac
 
-        subprocess.run(
+        subprocess.run(  # noqa: S603, warning about unsanitized subprocess
             cmd,
-            shell=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             check=True,
@@ -29,47 +41,57 @@ class InstallCommand(BaseModel):
 
 
 class Software:
-    def __init__(self, install_cmd: InstallCommand, check_cmd: str):
+    """
+    Class representing a software to install.
+
+    You should specify how to check if the software is installed and how to install it.
+    """
+
+    def __init__(self, install_cmd: InstallCommand, check_cmd: str) -> None:
         self.check_cmd = check_cmd
         self.install_cmd = install_cmd
 
-    def is_installed(self):
+    def is_installed(self) -> bool:
         try:
-            subprocess.run(
+            subprocess.run(  # noqa: S603 , warning about unsanitized subprocess
                 self.check_cmd,
-                shell=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 check=True,
             )
-            return True
         except subprocess.CalledProcessError:
             return False
+        else:
+            return True
 
-    def install(self):
+    def install(self) -> None:
         self.install_cmd.run()
 
 
-ffmpeg = Software(
-    install_cmd=InstallCommand(
-        win="winget install ffmpeg",
-        linux="sudo apt-get install ffmpeg",
-        mac="brew install ffmpeg",
-    ),
-    check_cmd="ffmpeg -version",
-)
+def setup_software() -> None:
+    """
+    Install all the required software for the script to work.
 
-handbrake_cli = Software(
-    install_cmd=InstallCommand(
-        win="winget install Handbrake.Handbrake.CLI",
-        linux="sudo apt-get install handbrake-cli",
-        mac="brew install handbrake-cli",
-    ),
-    check_cmd="handbrakecli --version",
-)
+    Including: FFmpeg and Handbrake CLI.
+    """
+    ffmpeg = Software(
+        install_cmd=InstallCommand(
+            win="winget install ffmpeg",
+            linux="sudo apt-get install ffmpeg",
+            mac="brew install ffmpeg",
+        ),
+        check_cmd="ffmpeg -version",
+    )
 
+    handbrake_cli = Software(
+        install_cmd=InstallCommand(
+            win="winget install Handbrake.Handbrake.CLI",
+            linux="sudo apt-get install handbrake-cli",
+            mac="brew install handbrake-cli",
+        ),
+        check_cmd="handbrakecli --version",
+    )
 
-def setup_software():
     if not ffmpeg.is_installed():
         log.wait("Installing FFmpeg...")
         ffmpeg.install()


### PR DESCRIPTION
# 📌 Proper HandbrakeCLI error handling

## 📝 Description  
There was a problem in determination of handbrakecli errors, because for wrong input it return zero (normal) exit codes.

The fix is to just simply watch output files, if there is no one - than some error happened, obviously.

## 🔄 Changelog  

- **✨ Added:**
    - Error handling for handbrake cli 
- **🛠 Fixed:**
    - Fixed logger skip_lines method
- **🔄 Changed:** …  
    - A little refactor of Install Module 

## 🎯 Related Issue  
Closes #2 

## ✅ Checklist  

- [x] Locally tested  
- [x] Essential tests added  
- [x] Documentation updated  
