### PR TITLE
Flag to skip unefficient compression 

### DIFF
--- a/CHANELOG.md
+++ b/CHANELOG.md
@@ -1,3 +1,7 @@
+# 0.3.0
+
+- Add argument to skip unefficient file compression.
+
 # 0.2.0:
 
 - Add smart filters to skip unwanted files.

--- a/main.py
+++ b/main.py
@@ -120,6 +120,14 @@ def main(  # noqa: PLR0913: too many arguments because of typer
             parser=VideoResolution.parse_resolution,
         ),
     ] = None,
+    keep_only_smaller: Annotated[
+        bool,
+        typer.Option(
+            '--keep-only-smaller',
+            '-k',
+            help='Should only videos smaller than the original be kept.',
+        ),
+    ] = False,
 ) -> None:
     """
     Compress your video files in batch with HandbrakeCLI.
@@ -200,6 +208,7 @@ def main(  # noqa: PLR0913: too many arguments because of typer
         complete_ext=complete_ext,
         handbrakecli_options=handbrakecli_options,
         smart_filter=smart_filter,
+        keep_only_smaller=keep_only_smaller,
     )
     compressor.compress_videos()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "batch-video-compressor"
-version = "0.2.0"
+version = "0.3.0"
 description = "Simple script to traverse all the video files and compress them to optimize disk space for large files"
 authors = [
     { name = "Roman Berezkin", email = "Glitchy-Sheep@users.noreply.github.com" },


### PR DESCRIPTION
# 📌 --keep-only-smaller argument

## 📝 Description  
Argument for deleting files that have become larger after encoding.

## 🔄 Changelog  

- **✨ Added:**
    - Add --keep-only-smaller argument

## ✅ Checklist  

- [x] Locally tested  
- [x] Essential tests added  
- [x] Documentation updated  