### PR TITLE
Remove junk files after compression

### DIFF
--- a/CHANELOG.md
+++ b/CHANELOG.md
@@ -1,3 +1,7 @@
+# 1.1.1
+
+- Remove junk log files after successful compression to not leave unnecessary traces.
+
 # 1.1.0
 
 - Add --version argument to show the version and exit.

--- a/handbrake_batch_compressor/main.py
+++ b/handbrake_batch_compressor/main.py
@@ -37,7 +37,7 @@ app = typer.Typer(
 
 def show_version_and_exit() -> None:
     """Show version and exit."""
-    __version__ = '1.1.0'
+    __version__ = '1.1.1'
     log.console.print(f'handbrake-batch-compressor {__version__}')
     sys.exit(0)
 

--- a/handbrake_batch_compressor/src/cli/statistics_logger.py
+++ b/handbrake_batch_compressor/src/cli/statistics_logger.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from handbrake_batch_compressor.src.utils.files import human_readable_size
 from rich.markup import escape
+
+from handbrake_batch_compressor.src.utils.files import human_readable_size
 
 if TYPE_CHECKING:
     from handbrake_batch_compressor.src.cli.logger import AppLogger

--- a/handbrake_batch_compressor/src/compression/compression_manager.py
+++ b/handbrake_batch_compressor/src/compression/compression_manager.py
@@ -4,14 +4,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from pydantic import BaseModel
+from rich.progress import Progress
+
 from handbrake_batch_compressor.src.cli.logger import log
 from handbrake_batch_compressor.src.cli.statistics_logger import StatisticsLogger
 from handbrake_batch_compressor.src.compression.compression_statistics import (
     CompressionStatistics,
 )
 from handbrake_batch_compressor.src.utils.ffmpeg_helpers import get_video_properties
-from pydantic import BaseModel
-from rich.progress import Progress
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/handbrake_batch_compressor/src/compression/handbrake_compressor.py
+++ b/handbrake_batch_compressor/src/compression/handbrake_compressor.py
@@ -68,4 +68,8 @@ class HandbrakeCompressor:
             )
             return False
 
+        # cleanup logs after a successful compression to not leave junk files
+        if stderr_log_filename.exists():
+            stderr_log_filename.unlink()
+
         return True

--- a/handbrake_batch_compressor/src/utils/third_party_installers.py
+++ b/handbrake_batch_compressor/src/utils/third_party_installers.py
@@ -3,8 +3,9 @@
 import os
 import subprocess
 
-from handbrake_batch_compressor.src.cli.logger import log
 from pydantic import BaseModel
+
+from handbrake_batch_compressor.src.cli.logger import log
 
 
 class InstallCommand(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "handbrake-batch-compressor"
-version = "1.1.0"
+version = "1.1.1"
 description = "Simple script to traverse all the video files and compress them to optimize disk space for large files"
 authors = [
     { name = "Roman Berezkin", email = "Glitchy-Sheep@users.noreply.github.com" },
@@ -30,7 +30,7 @@ coverage = "^7.6.10"
 
 [tool.poetry]
 name = "handbrake-batch-compressor"
-version = "1.1.0"
+version = "1.1.1"
 description = "Simple script to traverse all the video files and compress them to optimize disk space for large files"
 authors = ["Roman Berezkin"]
 readme = "README.md"


### PR DESCRIPTION
# 📌 Remove last_comrpession.log files after successful compression

## 📝 Description  
This files can be helpful only on failed jobs, so we should delete it after a successful one, so the utility won't leave junk after job is done.

## 🔄 Changelog  

- **✨ Added:**
    - Add log files removal  
- **🛠 Fixed:**
    - Organized imports 

## ✅ Checklist  

- [x] Locally tested  
- [x] Essential tests added  
- [x] Documentation updated  