### PR TITLE
docs: :memo: Add deploy-specific todos to the PR template.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,5 +22,9 @@ Describe in detail what has changed, why it is needed, and what problems this PR
 - [ ] Essential tests added  
 - [ ] Documentation updated  
 
+- [ ] Update changelog and versions everywhere (if necessary)
+- [ ] Add tags to a specific commit and push them to trigger a release (if necessary)
+
+
 ## ⚠ Notes  
 <!-- Any important notes about the PR. -->  


### PR DESCRIPTION
# 📌 Add deploy-specific todos to the PR template.

## 📝 Description  
Now we use PyPi and GitHub actions to publish a release everywhere, and each release should have a published tag to trigger the CI. So add it to our checklist.

## 🔄 Changelog  

- **✨ Added:**
    - 2 todos in the main pr-template 

## ✅ Checklist  

- [x] Locally tested  
- [x] Essential tests added  
- [x] Documentation updated  