### PR TITLE
Fix compression bug for VFS videos (with variable frame rate)

### DIFF
--- a/CHANELOG.md
+++ b/CHANELOG.md
@@ -1,3 +1,7 @@
+# 1.1.2
+
+- Fix the bug with crashing on videos with Variable Frame Rate (VFR)
+
 # 1.1.1
 
 - Remove junk log files after successful compression to not leave unnecessary traces.

--- a/handbrake_batch_compressor/main.py
+++ b/handbrake_batch_compressor/main.py
@@ -37,7 +37,7 @@ app = typer.Typer(
 
 def show_version_and_exit() -> None:
     """Show version and exit."""
-    __version__ = '1.1.1'
+    __version__ = '1.1.2'
     log.console.print(f'handbrake-batch-compressor {__version__}')
     sys.exit(0)
 

--- a/handbrake_batch_compressor/src/utils/ffmpeg_helpers.py
+++ b/handbrake_batch_compressor/src/utils/ffmpeg_helpers.py
@@ -149,6 +149,6 @@ def get_video_properties(video_path: Path) -> VideoProperties | None:
     else:
         return VideoProperties(
             resolution=resolution,
-            frame_rate=float(frame_rate),
+            frame_rate=frame_rate,
             bitrate_kbytes=bitrate_kbytes,
         )

--- a/handbrake_batch_compressor/src/utils/ffmpeg_helpers.py
+++ b/handbrake_batch_compressor/src/utils/ffmpeg_helpers.py
@@ -7,6 +7,7 @@ It will be used for smart filters.
 from __future__ import annotations
 
 import functools
+from fractions import Fraction
 from typing import TYPE_CHECKING
 
 import av
@@ -14,6 +15,9 @@ from pydantic import BaseModel
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from av.container.input import InputContainer
+    from av.video.stream import VideoStream
 
 
 class InvalidResolutionError(Exception):
@@ -83,6 +87,47 @@ class VideoProperties(BaseModel):
     bitrate_kbytes: int
 
 
+def estimate_fps_from_timestamps(
+    container: InputContainer,
+    stream: VideoStream,
+) -> Fraction | None:
+    """Estimate average FPS from timestamps for VFR (Variable Frame Rate) video."""
+    timestamps: list[Fraction] = [
+        Fraction(packet.pts, packet.time_base.denominator)  # Convert to Fraction
+        for packet in container.demux(stream)
+        if packet.pts is not None and packet.time_base is not None
+    ]
+
+    if len(timestamps) > 1:
+        intervals = [j - i for i, j in zip(timestamps[:-1], timestamps[1:])]
+        avg_interval = sum(intervals, start=Fraction(0)) / len(intervals)
+        return Fraction(1, avg_interval) if avg_interval > 0 else None
+
+    return None
+
+
+def extract_bitrate_from_stream(
+    container: InputContainer,
+    stream: VideoStream,
+) -> float:
+    """
+    Estimate FPS using the following methods:
+
+    - Codec Context
+    - Average Rate (if previous is unavailable)
+    - Timestamps (if previous is unavailable)
+    """
+    fps = stream.codec_context.framerate
+    if fps is None or fps == 0:
+        fps = stream.average_rate
+    if fps is None or fps == 0:
+        fps = estimate_fps_from_timestamps(container, stream)
+    if fps is None or fps == 0:
+        fps = 1.0
+
+    return float(fps)
+
+
 def get_video_properties(video_path: Path) -> VideoProperties | None:
     """
     Get the resolution, frame rate and bitrate of a video as a VideoProperties object.
@@ -96,7 +141,7 @@ def get_video_properties(video_path: Path) -> VideoProperties | None:
             width=stream.width,
             height=stream.height,
         )
-        frame_rate = stream.codec_context.framerate
+        frame_rate = extract_bitrate_from_stream(probe, stream)
         bitrate_kbytes = probe.bit_rate // 1024
         probe.close()
     except (av.InvalidDataError, IndexError):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "handbrake-batch-compressor"
-version = "1.1.1"
+version = "1.1.2"
 description = "Simple script to traverse all the video files and compress them to optimize disk space for large files"
 authors = [
     { name = "Roman Berezkin", email = "Glitchy-Sheep@users.noreply.github.com" },
@@ -30,7 +30,7 @@ coverage = "^7.6.10"
 
 [tool.poetry]
 name = "handbrake-batch-compressor"
-version = "1.1.1"
+version = "1.1.2"
 description = "Simple script to traverse all the video files and compress them to optimize disk space for large files"
 authors = ["Roman Berezkin"]
 readme = "README.md"

--- a/ruff.toml
+++ b/ruff.toml
@@ -16,7 +16,7 @@ ignore = [
 ]
 
 [lint.per-file-ignores]
-"test/*" = ["D", "ANN201", "S101", "PLR2004"]
+"test/*" = ["D", "ANN201", "S101", "PLR2004", "INP001"]
 "__init__.py" = ["D104"]
 
 [format]

--- a/test/compression_statistics_test.py
+++ b/test/compression_statistics_test.py
@@ -1,13 +1,17 @@
 from pathlib import Path
 
 import pytest
+
 from handbrake_batch_compressor.src.compression.compression_statistics import (
     CompressionStatistics,
 )
 
 
 @pytest.fixture
-def video_files(tmp_path: Path, request: pytest.FixtureRequest) -> tuple[Path, Path]:
+def video_files(
+    tmp_path: Path,
+    request: pytest.FixtureRequest,
+) -> tuple[Path, Path]:
     input_size = request.param['input_size']
     output_size = request.param['output_size']
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,8 +3,9 @@ from collections.abc import Generator
 from pathlib import Path
 
 import pytest
-from handbrake_batch_compressor.src.utils.files import supported_videofile_extensions
 from pydantic import BaseModel
+
+from handbrake_batch_compressor.src.utils.files import supported_videofile_extensions
 
 
 @pytest.fixture

--- a/test/ffmpeg_helpers_test.py
+++ b/test/ffmpeg_helpers_test.py
@@ -7,7 +7,7 @@ from handbrake_batch_compressor.src.utils.ffmpeg_helpers import (
 )
 
 
-def test_get_video_resolution(video_720p_2mb_mp4: Path):
+def test_get_video_properties(video_720p_2mb_mp4: Path):
     video_properties: VideoProperties | None = get_video_properties(
         video_720p_2mb_mp4,
     )

--- a/test/ffmpeg_helpers_test.py
+++ b/test/ffmpeg_helpers_test.py
@@ -8,9 +8,11 @@ from handbrake_batch_compressor.src.utils.ffmpeg_helpers import (
 
 
 def test_get_video_resolution(video_720p_2mb_mp4: Path):
-    video_properties: VideoProperties = get_video_properties(
+    video_properties: VideoProperties | None = get_video_properties(
         video_720p_2mb_mp4,
     )
+
+    assert video_properties is not None
 
     assert video_properties.resolution.width == 1280
     assert video_properties.resolution.height == 720

--- a/test/files_test.py
+++ b/test/files_test.py
@@ -2,7 +2,6 @@ from handbrake_batch_compressor.src.utils.files import (
     get_video_files_paths,
     human_readable_size,
 )
-
 from test.conftest import VideoSampleData
 
 


### PR DESCRIPTION
# 📌 Fix compression bug for VFS videos (with variable frame rate)

## 📝 Description  
The problem was in that the compression process did not handle videos with variable frame rates (VFR) correctly.
get_video_properties got None fps and the utility crashes.

So this PR uses multiple ways to get FPS/average FPS: codec context, stream, and calculation using timestamps:
```python
    fps = stream.codec_context.framerate
    if fps is None or fps == 0:
        fps = stream.average_rate
    if fps is None or fps == 0:
        fps = estimate_fps_from_timestamps(container, stream)
    if fps is None or fps == 0:
        fps = 1.0
```

In the worst case scenario fps will be set to 1.

## 🔄 Changelog  

- **✨ Added:**
    - Ignore for test/** files (INP001) 
- **🛠 Fixed:**
    - VFS bug 
- **🔄 Changed:**
    - Format some files

## 🎯 Related Issue  
Closes #20 

## ✅ Checklist  

- [x] Locally tested  
- [x] Essential tests added  
- [x] Documentation updated  

- [x] Update changelog and versions everywhere (if necessary)
- [x] Add tags to a specific commit and push them to trigger a release (if necessary)