### PR TITLE
Add compression cancellation feature (+exception based error handling)

### DIFF
--- a/CHANELOG.md
+++ b/CHANELOG.md
@@ -1,3 +1,8 @@
+# 1.1.3
+
+- Add possibility to gracefully stop the compression process by keyboard (ctrl + c).
+- More elegant error handling/logging system using custom exceptions.
+
 # 1.1.2
 
 - Fix the bug with crashing on videos with Variable Frame Rate (VFR)

--- a/handbrake_batch_compressor/main.py
+++ b/handbrake_batch_compressor/main.py
@@ -43,7 +43,7 @@ app = typer.Typer(
 
 def show_version_and_exit() -> None:
     """Show version and exit."""
-    __version__ = '1.1.2'
+    __version__ = '1.1.3'
     log.console.print(f'handbrake-batch-compressor {__version__}')
     sys.exit(0)
 

--- a/handbrake_batch_compressor/main.py
+++ b/handbrake_batch_compressor/main.py
@@ -23,6 +23,12 @@ from handbrake_batch_compressor.src.compression.compression_manager import (
 from handbrake_batch_compressor.src.compression.handbrake_compressor import (
     HandbrakeCompressor,
 )
+from handbrake_batch_compressor.src.errors.cancel_compression_by_user import (
+    CompressionCancelledByUserError,
+)
+from handbrake_batch_compressor.src.errors.handbrake_cli_exceptions import (
+    CompressionFailedError,
+)
 from handbrake_batch_compressor.src.utils.ffmpeg_helpers import VideoResolution
 from handbrake_batch_compressor.src.utils.files import get_video_files_paths
 from handbrake_batch_compressor.src.utils.smart_filters import SmartFilter
@@ -257,4 +263,11 @@ def main(  # noqa: PLR0913: too many arguments because of typer
 
 
 if __name__ == '__main__':
-    app()
+    try:
+        app()
+    except CompressionFailedError as e:
+        log.error(str(e))
+        sys.exit(1)
+    except CompressionCancelledByUserError as e:
+        log.success(str(e))
+        sys.exit(1)

--- a/handbrake_batch_compressor/src/errors/cancel_compression_by_user.py
+++ b/handbrake_batch_compressor/src/errors/cancel_compression_by_user.py
@@ -1,0 +1,8 @@
+"""Module for exceptions related to canceling compression by the user."""
+
+
+class CompressionCancelledByUserError(Exception):
+    """Exception raised when the compression is cancelled by the user."""
+
+    def __init__(self) -> None:
+        super().__init__('Compression cancelled by the user.')

--- a/handbrake_batch_compressor/src/errors/handbrake_cli_exceptions.py
+++ b/handbrake_batch_compressor/src/errors/handbrake_cli_exceptions.py
@@ -1,0 +1,12 @@
+"""Module for Handbrake CLI and compression-related exceptions."""
+
+from pathlib import Path
+
+
+class CompressionFailedError(Exception):
+    """Exception raised when the compression failed."""
+
+    def __init__(self, input_video: Path, stderr_log_filename: Path) -> None:
+        super().__init__(
+            f'Compression failed for {input_video.name}. Check {stderr_log_filename} for details.',
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "handbrake-batch-compressor"
-version = "1.1.2"
+version = "1.1.3"
 description = "Simple script to traverse all the video files and compress them to optimize disk space for large files"
 authors = [
     { name = "Roman Berezkin", email = "Glitchy-Sheep@users.noreply.github.com" },
@@ -30,7 +30,7 @@ coverage = "^7.6.10"
 
 [tool.poetry]
 name = "handbrake-batch-compressor"
-version = "1.1.2"
+version = "1.1.3"
 description = "Simple script to traverse all the video files and compress them to optimize disk space for large files"
 authors = ["Roman Berezkin"]
 readme = "README.md"


### PR DESCRIPTION
# 📌 Compression cancellation based on keyboard interruptions 

## 📝 Description  

This feature ensures that the video compression process can be gracefully cancelled by the user through a `KeyboardInterrupt` (such as pressing Ctrl+C in the terminal). When a user interrupts the compression process, the program will attempt to terminate the compression process cleanly, remove any incomplete output files, and raise a CompressionCancelledByUserError to signal the cancellation and log everything as needed.

## 🔄 Changelog  

- **✨ Added:**
    - Possibility to cancel the compression process properly with `ctrl + c` (with resource cleaning)
    - Custom exceptions under the `src/errors` 
- **🛠 Fixed:**:
    - Compression failing is more accurate and explicit now 

## 🎯 Related Issue  
Closes #19  

## ✅ Checklist  

- [x] Locally tested  
- [x] Essential tests added  
- [x] Documentation updated  
- [x] Update changelog and versions everywhere (if necessary)
- [x] Add tags to a specific commit and push them to trigger a release (if necessary)