### PR TITLE
Use ETA + Elapsed Time, enhance look of progress bars

### DIFF
--- a/CHANELOG.md
+++ b/CHANELOG.md
@@ -1,3 +1,7 @@
+# 2.1.0
+
+- Enhance look of progress bars. (Add elapsed time, better formatting, panels)
+
 # 2.0.1
 
 - Fix a bug with encoding in utf-8.

--- a/handbrake_batch_compressor/main.py
+++ b/handbrake_batch_compressor/main.py
@@ -212,7 +212,7 @@ def main(  # noqa: PLR0913: too many arguments because of typer
 
     if len(video_files) == 0:
         log.success('No video files found. - Nothing to do.')
-        sys.exit(1)
+        sys.exit(0)
 
     log.success(f'Found {len(video_files)} video files.')
 
@@ -280,10 +280,12 @@ def bootstrap() -> None:
     try:
         app()
 
-    # Can be thrown by typer/clink internally during KeyboardInterrupt
-    except SystemExit:
-        actual_exception = CompressionCancelledByUserError()
-        log.success(str(actual_exception))
+    # Typer will throw 130 exit code on ctrl + c interruption
+    except SystemExit as e:
+        sigterm_code = 130
+        if e.code == sigterm_code:
+            actual_exception = CompressionCancelledByUserError()
+            log.success(str(actual_exception))
     except CompressionFailedError as e:
         log.error(str(e))
     except CompressionCancelledByUserError as e:

--- a/handbrake_batch_compressor/main.py
+++ b/handbrake_batch_compressor/main.py
@@ -43,7 +43,7 @@ app = typer.Typer(
 
 def show_version_and_exit() -> None:
     """Show version and exit."""
-    __version__ = '2.0.1'
+    __version__ = '2.1.0'
     log.raw_log(f'handbrake-batch-compressor {__version__}')
     sys.exit(0)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "handbrake-batch-compressor"
-version = "2.0.1"
+version = "2.1.0"
 description = "Simple script to traverse all the video files and compress them to optimize disk space for large files"
 authors = [
     { name = "Roman Berezkin", email = "Glitchy-Sheep@users.noreply.github.com" },
@@ -31,7 +31,7 @@ coverage = "^7.6.10"
 
 [tool.poetry]
 name = "handbrake-batch-compressor"
-version = "2.0.1"
+version = "2.1.0"
 description = "Simple script to traverse all the video files and compress them to optimize disk space for large files"
 authors = ["Roman Berezkin"]
 readme = "README.md"


### PR DESCRIPTION
# 📌 Use ETA + Elapsed Time, enhance look of progress bars

## 📝 Description  
Use ETA only for current task and elapsed time for general progress, because it's more detailed and accurate in this case.
I've also found a bug at the root exception handlers (SystemExit == 0) and fix it with code comparison.

## 🔄 Changelog  

- **🛠 Fixed:**
    - Root exception handler bug with SystemExit(0) (prints cancellation message even though it wasn't cancelled) 
- **🔄 Changed:**
    - Reformat progress bars to make it look better and be more informative 


## 🎯 Related Issue  
Closes #23 

## 📷 Screenshots (if applicable)  
![image](https://github.com/user-attachments/assets/a593e6af-3d9e-4afa-9bec-d7cddabeaa12)

## ✅ Checklist  

- [x] Locally tested  
- [x] Essential tests added  
- [x] Documentation updated  
- [x] Update changelog and versions everywhere (if necessary)
- [x] Add tags to a specific commit and push them to trigger a release (if necessary)

